### PR TITLE
Calendar - Update day background color with selection.

### DIFF
--- a/js/calendar.js
+++ b/js/calendar.js
@@ -1,6 +1,7 @@
 class Calendar {
     constructor(selectionSync) {
         this.selectionSync = selectionSync;
+        selectionSync.calendar = this;
     }
 
     show() {
@@ -18,13 +19,32 @@ class Calendar {
             .attr("height", "100%");
     }
 
-    dayRectCss(d) {
-        let cssClass = 'calendar-day-box';
-        if (d === null) return cssClass;
-        const forecasts = this.data.get(d.toJSON());
-        const max = AvalancheDangerColor.LEVELS[forecasts.max];
-        const min = AvalancheDangerColor.LEVELS[forecasts.min];
-        return `${cssClass} bg-uac-${max}-${min}`
+    forecastForDay(day) {
+        return this.data.get(day.toJSON());
+    }
+
+    dayBackgroundColor(day, uacID = null) {
+        if (day === null) {
+            return `${Calendar.DAYS_BG_CSS} empty`;
+        }
+
+        const forecasts = this.forecastForDay(day);
+        if (uacID !== null) {
+            const background = AvalancheDangerColor.LEVELS[
+                forecasts.values[uacID]
+                ];
+            return `${Calendar.DAYS_BG_CSS} uac-${background}`;
+        } else {
+            const max = AvalancheDangerColor.LEVELS[forecasts.max];
+            const min = AvalancheDangerColor.LEVELS[forecasts.min];
+            return `${Calendar.DAYS_BG_CSS} bg-uac-${max}-${min}`
+        }
+    }
+
+    daysUacIdBG(uacID) {
+        this.days
+            .selectAll('rect')
+            .attr("class", (d) => this.dayBackgroundColor(d, uacID));
     }
 
     addDays(date) {
@@ -51,9 +71,8 @@ class Calendar {
             .attr("width", Calendar.CELL_DIM)
             .attr("height", Calendar.CELL_DIM)
             .attr('rx', 4)
-            .attr("class", (d) => this.dayRectCss(d))
+            .attr('class', (d) => this.dayBackgroundColor(d))
             .classed('selected', (d) => d && d.getTime() === date.getTime())
-            .classed('empty', (d) => d === null)
             .on('click', function(e, d) {
                 e.stopPropagation();
                 that.selectDate(d);
@@ -81,3 +100,4 @@ class Calendar {
 Calendar.CELL_SIZE = 50;  // in pixels
 Calendar.CELL_SPACE = 5;
 Calendar.CELL_DIM = Calendar.CELL_SIZE - Calendar.CELL_SPACE;
+Calendar.DAYS_BG_CSS = 'calendar-day-box';

--- a/js/selection_sync.js
+++ b/js/selection_sync.js
@@ -1,4 +1,7 @@
 class SelectionSync {
+    get calendar() { return this._calendar }
+    set calendar(value) { this._calendar = value; }
+
     get map() { return this._map }
     set map(value) { this._map = value; }
 
@@ -31,6 +34,9 @@ class SelectionSync {
             text = '<i>Marker Info</i>' + this.markerInfoText();
             this.rose.selectPetal(this.map.currentMarker.uacInfo.uacID);
             this.setRoseInfo();
+            this.calendar.daysUacIdBG(this.map.currentMarker.uacInfo.uacID);
+        } else if (this.calendar.days) {
+            this.calendar.daysUacIdBG(null);
         }
         this.markerSpan.html(text);
     }
@@ -62,6 +68,9 @@ class SelectionSync {
             } else if (typeof(value) === 'string') {
                 text += value;
             }
+            this.calendar.daysUacIdBG(value.data);
+        } else if (this.calendar.days) {
+            this.calendar.daysUacIdBG(null);
         }
         this.roseSpan.html(text);
     }


### PR DESCRIPTION
Update the day background of the calendar with the forecast avy level
once a user selects a petal in the rose or sets a marker on the map.

Fixes #4